### PR TITLE
feat(ui): add login/logout flow and gate UI behind auth

### DIFF
--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -1,0 +1,96 @@
+/* Auth screen card */
+.auth {
+  max-width: 380px;
+  margin: 10vh auto;
+  background: var(--panel, #17181c);
+  border: 1px solid var(--border, #2a2d34);
+  border-radius: 12px;
+  padding: 22px 20px;
+  box-shadow: 0 6px 18px var(--shadow, rgba(0,0,0,0.35));
+  color: var(--ink, #333);
+}
+
+.auth h1 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.auth .muted {
+  color: var(--muted, #9aa3af);
+  font-size: 13px;
+  text-align: center;
+  margin-bottom: 14px;
+}
+
+.auth .auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.auth label.row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.auth .lbl {
+  font-size: 13px;
+  color: var(--muted, #9aa3af);
+}
+
+.auth input[type="text"],
+.auth input[type="password"] {
+  padding: 10px 12px;
+  border: 1px solid var(--border, #2a2d34);
+  border-radius: 8px;
+  background: var(--bg, #0f1115);
+  color: var(--ink, #eaeef2);
+  outline: none;
+}
+
+.auth input:focus {
+  border-color: #5c6bc0;
+  box-shadow: 0 0 0 2px rgba(92,107,192,0.25);
+}
+
+.auth .btns {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+  justify-content: space-between;
+}
+
+.auth .btn {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: var(--button-bg, #394150);
+  color: var(--button-text, #fff);
+  cursor: pointer;
+  flex: 1;
+  font-size: 14px;
+}
+
+.auth .btn.primary { background: #5c6bc0; }
+.auth .btn.danger  { background: #e53935; }
+.auth .btn.outline {
+  /* background: transparent; */
+  border-color: var(--border, #2a2d34);
+}
+
+.auth .btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.auth .msg {
+  margin-top: 10px;
+  font-size: 13px;
+  text-align: center;
+}
+
+.auth .msg.ok   { color: #69db7c; }
+.auth .msg.err  { color: #ff6b6b; }

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <!-- global app roots -->
+  <div id="auth-root"></div>
   <div id="sidebar-root"></div>
   <div id="menubar-root"></div>
   <div id="viewer-root" style="display:none"></div>

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,54 +1,91 @@
 // /static/js/api.js
-// centralized backend API helpers
 
-export async function ping() {
-  const res = await fetch("/api/ping");
-  if (!res.ok) throw new Error(res.statusText);
-  return res.text(); // "pong"
+// ---------- small utils ----------
+function encKeyForPath(k) {
+  return (k || "").split("/").map(encodeURIComponent).join("/");
+}
+function respError(r, bodyText) {
+  const msg = `HTTP ${r.status} ${r.statusText}${bodyText ? ` — ${bodyText}` : ""}`;
+  const err = new Error(msg);
+  err.status = r.status;
+  return err;
 }
 
-export async function listObjects() {
-  const res = await fetch("/api/objects?recursive=1");
-  if (!res.ok) throw new Error(res.statusText);
-  const data = await res.json();
+// ---------- auth ----------
+export async function signup(username, password) {
+  const r = await fetch("/api/auth/signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password })
+  });
+  if (!r.ok) throw respError(r, await r.text().catch(() => ""));
+  const detail = { username };
+  window.dispatchEvent(new CustomEvent("api:signupSuccess", { detail }));
+  return true;
+}
 
-  // unwrap if backend sends { objects: [...] }
-  if (data && typeof data === "object" && !Array.isArray(data)) {
-    if (Array.isArray(data.objects)) return data.objects;
+export async function login(username, password, opts = {}) {
+  // ttl_secs will be clamped by server (AUTH_MAX_TTL_SECS)
+  const r = await fetch("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      username,
+      password,
+      ttl_secs: opts.ttl_secs ?? 3600,
+      scope: opts.scope // optional string
+    })
+  });
+  if (!r.ok) {
+    const txt = await r.text().catch(() => "");
+    const err = respError(r, txt);
+    window.dispatchEvent(new CustomEvent("api:loginError", { detail: { error: err.message } }));
+    throw err;
   }
-
-  if (!Array.isArray(data)) {
-    throw new Error("Invalid objects payload");
-  }
-
+  const data = await r.json();
+  // Cookie (rb_token) is set HttpOnly by the proxy; we also broadcast for UI.
+  window.dispatchEvent(new CustomEvent("api:loginSuccess", { detail: { username, token: data } }));
   return data;
 }
 
-/**
- * Upload an object
- * @param {string} key   object key (usually file.name)
- * @param {File|Blob} file   the raw file data
- * @param {Object} [opts]    optional fetch options (headers, overwrite control, etc.)
- */
-export async function uploadObject(key, file, opts = {}) {
-  const res = await fetch(`/api/objects/${encodeURIComponent(key)}`, {
-    method: "PUT",
-    body: file,
-    headers: opts.headers || {},
-  });
-
-  if (!res.ok) throw new Error(await res.text() || res.statusText);
-  return res;
+export async function logout() {
+  const r = await fetch("/api/auth/logout", { method: "POST" });
+  if (!r.ok) throw respError(r, await r.text().catch(() => ""));
+  window.dispatchEvent(new Event("api:loggedOut"));
+  return true;
 }
 
-/**
- * Delete an object
- * @param {string} key
- */
-export async function deleteObject(key) {
-  const res = await fetch(`/api/objects/${encodeURIComponent(key)}`, {
-    method: "DELETE",
+// ---------- existing helpers (unchanged semantics) ----------
+export async function ping() {
+  const r = await fetch("/api/ping");
+  if (!r.ok) throw respError(r, await r.text().catch(() => ""));
+  return r.text();
+}
+
+export async function listObjects(params = {}) {
+  const qp = new URLSearchParams();
+  if (params.recursive) qp.set("recursive", "1");
+  if (params.prefix) qp.set("prefix", params.prefix);
+  const url = "/api/objects" + (qp.toString() ? `?${qp}` : "");
+  const r = await fetch(url);
+  if (!r.ok) throw respError(r, await r.text().catch(() => ""));
+  return r.json(); // [{key,size,modified}]
+}
+
+export async function uploadObject(key, file) {
+  key = encKeyForPath(key);
+  const r = await fetch(`/api/objects/${key}`, {
+    method: "PUT",
+    headers: { "Content-Type": file.type || "application/octet-stream" },
+    body: file
   });
-  if (!res.ok) throw new Error(await res.text() || res.statusText);
-  return res;
+  if (!r.ok) throw respError(r, await r.text().catch(() => ""));
+  return true;
+}
+
+export async function deleteObject(key) {
+  key = encKeyForPath(key);
+  const r = await fetch(`/api/objects/${key}`, { method: "DELETE" });
+  if (r.status === 204) return true;
+  throw respError(r, await r.text().catch(() => ""));
 }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,0 +1,124 @@
+import { signup, login } from "/static/js/api.js";
+
+(function loadAuthCSS() {
+  if (!document.querySelector('link[href="/static/css/auth.css"]')) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/static/css/auth.css";
+    document.head.appendChild(link);
+  }
+})();
+
+function el(t, cls, text) {
+  const n = document.createElement(t);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+export function createAuth() {
+  const wrap = el("div", "auth");
+  const title = el("h1", null, "🔐 Sign in to rust-buck3t");
+  const sub = el("p", "muted", "[decentralize.] 🫵🏽");
+
+  const form = el("div", "auth-form");
+
+  const uRow = el("label", "row");
+  uRow.appendChild(el("span", "lbl", "Username"));
+  const uInput = el("input");
+  uInput.type = "text";
+  uInput.placeholder = "c0nsume";
+  uInput.autocomplete = "username";
+  uRow.appendChild(uInput);
+
+  const pRow = el("label", "row");
+  pRow.appendChild(el("span", "lbl", "Password"));
+  const pInput = el("input");
+  pInput.type = "password";
+  pInput.placeholder = "••••••••";
+  pInput.autocomplete = "current-password";
+  pRow.appendChild(pInput);
+
+  const btns = el("div", "btns");
+  const signBtn   = el("button", "btn outline", "Sign up");
+  const loginBtn  = el("button", "btn primary", "Log in");
+
+  btns.appendChild(signBtn);
+  btns.appendChild(loginBtn);
+
+  const msg = el("div", "msg muted", "");
+
+  form.appendChild(uRow);
+  form.appendChild(pRow);
+  form.appendChild(btns);
+
+  wrap.appendChild(title);
+  wrap.appendChild(sub);
+  wrap.appendChild(form);
+  wrap.appendChild(msg);
+
+  const setBusy = (on) => {
+    signBtn.disabled = on;
+    loginBtn.disabled = on;
+  };
+
+  const say = (text, cls = "muted") => {
+    msg.className = "msg " + cls;
+    msg.textContent = text;
+    if (cls !== "muted") {
+      clearTimeout(say._t);
+      say._t = setTimeout(() => { msg.className = "msg muted"; msg.textContent = ""; }, 3000);
+    }
+  };
+
+  // Enter submits login
+  const maybeLogin = async () => {
+    const username = uInput.value.trim();
+    const password = pInput.value;
+    if (!username || !password) return say("enter username and password", "err");
+    try {
+      setBusy(true);
+      const tok = await login(username, password, { ttl_secs: 3600 });
+      say("Signed in", "ok");
+    } catch (e) {
+      say(e.message || "login failed", "err");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  signBtn.addEventListener("click", async () => {
+    const username = uInput.value.trim();
+    const password = pInput.value;
+    if (!username || !password) return say("enter username and password", "err");
+    try {
+      setBusy(true);
+      await signup(username, password);
+      say("signup ok — now log in", "ok");
+      pInput.focus();
+    } catch (e) {
+      say(e.message || "signup failed", "err");
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  loginBtn.addEventListener("click", maybeLogin);
+
+  // submit on Enter in either field
+  [uInput, pInput].forEach(inp => {
+    inp.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        maybeLogin();
+      }
+    });
+  });
+
+  // reflect API events (optional)
+  window.addEventListener("api:loginError", (e) => {
+    say(e.detail?.error || "login failed", "err");
+  });
+
+  return wrap;
+}

--- a/static/js/menubar.js
+++ b/static/js/menubar.js
@@ -140,6 +140,11 @@ export function createMenuBar() {
     { label: "About", onClick: () => alert("Image Generator v1.0") }
   ]));
 
+  // ACCOUNT STUFF
+  menuList.appendChild(makeMenu("Account", [
+    { label: "Log out", onClick: () => window.dispatchEvent(new Event("app:logout")) }
+  ]));
+
   nav.appendChild(menuList);
 
   // --- set initial theme ---


### PR DESCRIPTION
This PR introduces authentication flow to the frontend and integrates it into the app lifecycle.

## Auth Component
- New `auth.js` module renders signup + login form
- Dynamically loads `auth.css`
- Handles submit on Enter, shows status messages
- Dispatches and responds to `api:login*` events

## API Helpers
- Expanded `api.js` with auth functions: `signup`, `login`, `logout`
- Added `encKeyForPath()` and `respError()` utilities
- Dispatch browser events for login/signup success/failure and logout
- Updated object helpers to use consistent error handling

## App Orchestration
- Added `auth-root` and `createAuth()` mount point
- App boots in **auth mode**; viewer/upload/settings only mount after login
- Chrome (menubar/sidebar) mounts after `api:loginSuccess`
- On `api:loggedOut`, chrome and all roots are reset to auth
- Added `app:logout` event → calls `logout()` API
- Removed viewer boot; all object actions now require login

## Account (in the menubar)
- Added temporary account section to host logout functionality
- Prepares groundwork for richer account settings later
